### PR TITLE
kvmetainfo: ensure that the UserDefined map is not nil

### DIFF
--- a/private/metainfo/kvmetainfo/objects.go
+++ b/private/metainfo/kvmetainfo/objects.go
@@ -498,6 +498,11 @@ func objectFromMeta(bucket storj.Bucket, path storj.Path, listItem storj.ObjectL
 			return storj.Object{}, err
 		}
 
+		// ensure that the map is not nil
+		if serializableMeta.UserDefined == nil {
+			serializableMeta.UserDefined = map[string]string{}
+		}
+
 		_, found := serializableMeta.UserDefined[contentTypeKey]
 		if !found && serializableMeta.ContentType != "" {
 			serializableMeta.UserDefined[contentTypeKey] = serializableMeta.ContentType


### PR DESCRIPTION
What: Ensures that the UserDefined map is not nil

Why: https://github.com/storj/gateway/issues/2

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
