### PR TITLE
config,expose: add tls options to config

### DIFF
--- a/internal/expose/exposed.go
+++ b/internal/expose/exposed.go
@@ -22,3 +22,8 @@ var GetObjectIPs interface{}
 //
 // func SetConnectionPool(ctx context.Context, config *uplink.Config, pool *rpcpool.Pool) error.
 var SetConnectionPool interface{}
+
+// SetTLSOptions exposes uplink.setTLSOptions.
+//
+// func SetTLSOptions(ctx context.Context, config *uplink.Config, tlsOptions *tlsopts.Options) error {
+var SetTLSOptions interface{}

--- a/private/transport/transport.go
+++ b/private/transport/transport.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/zeebo/errs"
 
+	"storj.io/common/peertls/tlsopts"
 	"storj.io/common/rpc/rpcpool"
 	"storj.io/uplink"
 	"storj.io/uplink/internal/expose"
@@ -21,4 +22,14 @@ func SetConnectionPool(ctx context.Context, config *uplink.Config, pool *rpcpool
 		return errs.New("invalid type %T", fn)
 	}
 	return fn(ctx, config, pool)
+}
+
+// SetTLSOptions configures TLS configuration on the passed in config. If
+// argument tlsOptions is nil, it will clear the TLS configuration on the config.
+func SetTLSOptions(ctx context.Context, config *uplink.Config, tlsOptions *tlsopts.Options) error {
+	fn, ok := expose.SetTLSOptions.(func(ctx context.Context, config *uplink.Config, tlsOptions *tlsopts.Options) error)
+	if !ok {
+		return errs.New("invalid type %T", fn)
+	}
+	return fn(ctx, config, tlsOptions)
 }


### PR DESCRIPTION
Since the connection pooling is using *tlsopt.Options as part of its key
for connection cache, we need to be able to reuse a tls option instead
of creating new ones each time we get a dialer

Change-Id: I076e1e63725c863129869ff4917d4000d711d06c


What: 

Why:

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
