### PR TITLE
Update the URL of the whitepaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Go library for Storj V3 Network.
 <img src="https://github.com/storj/storj/raw/main/resources/logo.png" width="100">
 
 Storj is building a decentralized cloud storage network.
-[Check out our white paper for more info!](https://storj.io/white-paper)
+[Check out our white paper for more info!](https://storj.io/whitepaper)
 
 ----
 


### PR DESCRIPTION
What: 

Fixing typo in the README: whitepaper URL recently changed from https://www.storj.io/white-paper to https://www.storj.io/whitepaper  

Why:

A more robust solution would be to configure a permanent redirect on the webhost. But other repositories already have updated URL (for example storj repo with storj/storj#4107)

Please describe the tests:
 - Test 1: :eyes: 
 - Test 2: :computer_mouse:  
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
