### PR TITLE
private/stream: add `ReadAt` method to `stream.Download`

### DIFF
--- a/download.go
+++ b/download.go
@@ -118,6 +118,14 @@ func (download *Download) Read(p []byte) (n int, err error) {
 	return n, convertKnownErrors(err, download.bucket, download.object.Key)
 }
 
+// ReadAt reads len(p) bytes into p starting at offset off in the
+// underlying input source. It returns the number of bytes
+// read (0 <= n <= len(p)) and any error encountered.
+func (download *Download) ReadAt(p []byte, off int64) (n int, err error) {
+	n, err = download.download.ReadAt(p, off)
+	return n, convertKnownErrors(err, download.bucket, download.object.Key)
+}
+
 // Close closes the reader of the download.
 func (download *Download) Close() error {
 	err := errs.Combine(


### PR DESCRIPTION
What: Add ReadAt method to stream.Download

Why: 
This helps to more cleanly support parallelism for uploads and downloads
and ranged downloads

Please describe the tests:
 - Test 1:
 - Test 2:
 
Please describe the performance impact:

## Code Review Checklist (to be filled out by reviewer)
 - [ ] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [ ] Does the PR describe what changes are being made?
 - [ ] Does the PR describe why the changes are being made?
 - [ ] Does the code follow [our style guide](https://github.com/storj/docs/blob/main/code/Style.md)?
 - [ ] Does the code follow [our testing guide](https://github.com/storj/docs/blob/main/code/Testing.md)?
 - [ ] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [ ] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [ ] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [ ] Does any documentation need updating?
 - [ ] Do the database access patterns make sense?
 
