### PR TITLE
fix: "uplink: invalid access grant format"

### DIFF
--- a/examples/walkthrough/main.go
+++ b/examples/walkthrough/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/joho/godotenv"
 	"storj.io/uplink"
 )
 
@@ -79,6 +80,12 @@ func UploadAndDownloadData(ctx context.Context,
 	}
 
 	return nil
+}
+
+func init() {
+	if err := godotenv.Load(".env"); err != nil {
+		log.Fatal("[FATAL] Error loading .env file")
+	}
 }
 
 func main() {


### PR DESCRIPTION
Initialize program with godotenv lib


What:  Read ACCESS_GRANT from .env file

Why: Uplink failing to validate ACCESS_GRANT because it is not set