### PR TITLE
Add support for unencrypted object metadata

### DIFF
--- a/access.go
+++ b/access.go
@@ -206,6 +206,9 @@ func config_requestAccessWithPassphraseAndConcurrency(config Config, ctx context
 	if config.disableObjectKeyEncryption {
 		encAccess.SetDefaultPathCipher(storj.EncNull)
 	}
+	if config.disableObjectMetadataEncryption {
+		encAccess.SetDefaultMetadataCipher(storj.EncNull)
+	}
 	encAccess.LimitTo(parsedAPIKey)
 
 	return &Access{

--- a/config.go
+++ b/config.go
@@ -76,6 +76,16 @@ type Config struct {
 	// Object content is still encrypted as usual.
 	disableObjectKeyEncryption bool
 
+	// disableObjectMetadataEncryption disables the encryption of object
+	// metadata for newly uploaded objects.
+	//
+	// Disabling the encryption of object metadata means that the object
+	// metadata is stored in plain text in the satellite database. This allows
+	// object search based on metadata values.
+	//
+	// Object content encryption is not affected by this flag.
+	disableObjectMetadataEncryption bool
+
 	// disableBackgroundQoS tells the uplink library to not try setting background
 	// QoS flags on the network sockets. This will impact the congestion control
 	// profile as well.
@@ -179,6 +189,18 @@ func config_setMaximumBufferSize(config *Config, maximumBufferSize int) {
 //go:linkname config_disableObjectKeyEncryption
 func config_disableObjectKeyEncryption(config *Config) {
 	config.disableObjectKeyEncryption = true
+}
+
+// disableObjectMetadataEncryption exposes setting disableObjectMetadataEncryption.
+//
+// NB: this is used with linkname in internal/expose.
+// It needs to be updated when this is updated.
+//
+//lint:ignore U1000, used with linkname
+//nolint:unused
+//go:linkname config_disableObjectMetadataEncryption
+func config_disableObjectMetadataEncryption(config *Config) {
+	config.disableObjectMetadataEncryption = true
 }
 
 func (config Config) validateUserAgent(ctx context.Context) error {

--- a/internal/expose/expose.go
+++ b/internal/expose/expose.go
@@ -40,6 +40,11 @@ func ConfigSetMaximumBufferSize(*uplink.Config, int)
 //go:linkname ConfigDisableObjectKeyEncryption storj.io/uplink.config_disableObjectKeyEncryption
 func ConfigDisableObjectKeyEncryption(config *uplink.Config)
 
+// ConfigDisableObjectMetadataEncryption exposes Config.disableObjectMetadataEncryption.
+//
+//go:linkname ConfigDisableObjectMetadataEncryption storj.io/uplink.config_disableObjectMetadataEncryption
+func ConfigDisableObjectMetadataEncryption(config *uplink.Config)
+
 // AccessGetAPIKey exposes Access.getAPIKey.
 //
 //go:linkname AccessGetAPIKey storj.io/uplink.access_getAPIKey

--- a/private/access/access.go
+++ b/private/access/access.go
@@ -32,3 +32,15 @@ func APIKey(access *uplink.Access) *macaroon.APIKey {
 func DisableObjectKeyEncryption(config *uplink.Config) {
 	expose.ConfigDisableObjectKeyEncryption(config)
 }
+
+// DisableObjectMetadataEncryption disables the encryption of object metadata for newly
+// uploaded objects.
+//
+// Disabling the encryption of object metadata means that the object
+// metadata is stored in plain text in the satellite database. This allows
+// object search based on metadata values.
+//
+// Object content encryption is not affected by this flag.
+func DisableObjectMetadataEncryption(config *uplink.Config) {
+	expose.ConfigDisableObjectMetadataEncryption(config)
+}

--- a/private/metaclient/client.go
+++ b/private/metaclient/client.go
@@ -615,6 +615,7 @@ type BeginObjectParams struct {
 	EncryptedMetadata             []byte
 	EncryptedMetadataEncryptedKey []byte
 	EncryptedMetadataNonce        storj.Nonce
+	ClearMetadata                 []byte
 
 	Retention Retention
 	LegalHold bool
@@ -643,6 +644,7 @@ func (params *BeginObjectParams) toRequest(header *pb.RequestHeader) *pb.ObjectB
 		EncryptedMetadata:             params.EncryptedMetadata,
 		EncryptedMetadataEncryptedKey: params.EncryptedMetadataEncryptedKey,
 		EncryptedMetadataNonce:        params.EncryptedMetadataNonce,
+		ClearMetadata:                 params.ClearMetadata,
 		LegalHold:                     params.LegalHold,
 	}
 

--- a/private/metaclient/client.go
+++ b/private/metaclient/client.go
@@ -699,6 +699,7 @@ type CommitObjectParams struct {
 	EncryptedMetadataNonce        storj.Nonce
 	EncryptedMetadata             []byte
 	EncryptedMetadataEncryptedKey []byte
+	ClearMetadata                 []byte
 }
 
 func (params *CommitObjectParams) toRequest(header *pb.RequestHeader) *pb.ObjectCommitRequest {
@@ -708,6 +709,7 @@ func (params *CommitObjectParams) toRequest(header *pb.RequestHeader) *pb.Object
 		EncryptedMetadataNonce:        params.EncryptedMetadataNonce,
 		EncryptedMetadata:             params.EncryptedMetadata,
 		EncryptedMetadataEncryptedKey: params.EncryptedMetadataEncryptedKey,
+		ClearMetadata:                 params.ClearMetadata,
 	}
 }
 

--- a/private/metaclient/client.go
+++ b/private/metaclient/client.go
@@ -1275,6 +1275,7 @@ func newListObjectsResponse(response *pb.ObjectListResponse, encryptedPrefix []b
 			EncryptedMetadataNonce:        object.EncryptedMetadataNonce,
 			EncryptedMetadataEncryptedKey: object.EncryptedMetadataEncryptedKey,
 			EncryptedMetadata:             object.EncryptedMetadata,
+			ClearMetadata:                 object.ClearMetadata,
 
 			IsPrefix: isPrefix,
 		}
@@ -1361,6 +1362,7 @@ func newListPendingObjectStreamsResponse(response *pb.ObjectListPendingStreamsRe
 			PlainSize:              object.PlainSize,
 			EncryptedMetadataNonce: object.EncryptedMetadataNonce,
 			EncryptedMetadata:      object.EncryptedMetadata,
+			ClearMetadata:          object.ClearMetadata,
 
 			IsPrefix: false,
 		}

--- a/private/metaclient/client.go
+++ b/private/metaclient/client.go
@@ -817,6 +817,7 @@ func newObjectInfo(object *pb.Object) RawObjectItem {
 		EncryptedMetadata:             object.EncryptedMetadata,
 		EncryptedMetadataNonce:        object.EncryptedMetadataNonce,
 		EncryptedMetadataEncryptedKey: object.EncryptedMetadataEncryptedKey,
+		ClearMetadata:                 object.ClearMetadata,
 	}
 
 	if object.Retention != nil {

--- a/private/metaclient/objects.go
+++ b/private/metaclient/objects.go
@@ -15,6 +15,7 @@ import (
 	"storj.io/common/paths"
 	"storj.io/common/pb"
 	"storj.io/common/storj"
+	"storj.io/common/usermeta"
 )
 
 var contentTypeKey = "content-type"
@@ -859,6 +860,14 @@ func (db *DB) ObjectFromRawObjectItem(ctx context.Context, bucket, key string, o
 	err = updateObjectWithStream(&object, streamInfo, streamMeta)
 	if err != nil {
 		return Object{}, err
+	}
+
+	if objectInfo.ClearMetadata != nil {
+		meta, err := usermeta.Unmarshal(objectInfo.ClearMetadata)
+		if err != nil {
+			return Object{}, err
+		}
+		object.Metadata = meta
 	}
 
 	return object, nil

--- a/private/metaclient/objects.go
+++ b/private/metaclient/objects.go
@@ -899,6 +899,13 @@ func (db *DB) objectFromRawObjectListItem(bucket string, path storj.Path, listIt
 		return Object{}, err
 	}
 
+	if listItem.ClearMetadata != nil {
+		object.Metadata, err = usermeta.Unmarshal(listItem.ClearMetadata)
+		if err != nil {
+			return Object{}, err
+		}
+	}
+
 	return object, nil
 }
 

--- a/private/metaclient/types.go
+++ b/private/metaclient/types.go
@@ -75,6 +75,7 @@ type RawObjectListItem struct {
 	EncryptedMetadataNonce        storj.Nonce
 	EncryptedMetadataEncryptedKey []byte
 	EncryptedMetadata             []byte
+	ClearMetadata                 []byte
 
 	IsPrefix bool
 }

--- a/private/metaclient/types.go
+++ b/private/metaclient/types.go
@@ -28,6 +28,7 @@ type RawObjectItem struct {
 	EncryptedMetadataNonce        storj.Nonce
 	EncryptedMetadataEncryptedKey []byte
 	EncryptedMetadata             []byte
+	ClearMetadata                 []byte
 
 	EncryptionParameters storj.EncryptionParameters
 	RedundancyScheme     storj.RedundancyScheme

--- a/project_multipart.go
+++ b/project_multipart.go
@@ -66,6 +66,30 @@ func encryptPath(project *Project, bucket, key string) (paths.Encrypted, error) 
 	return encPath, err
 }
 
+// getMetadataCipher is exposing helper method to get cipher for a key using project internals.
+//
+// NB: this is used with linkname in private/multipart.
+// It needs to be updated when this is updated.
+//
+//lint:ignore U1000, used with linkname
+//nolint:unused
+//go:linkname getMetadataCipher
+func getMetadataCipher(project *Project, bucket, key string) storj.CipherSuite {
+	encStore := project.access.encAccess.Store
+	path := paths.NewUnencrypted(key)
+
+	if !path.Valid() {
+		return encStore.GetDefaultMetadataCipher()
+	}
+
+	_, _, base := encStore.LookupUnencrypted(bucket, path)
+	if base == nil {
+		return encStore.GetDefaultMetadataCipher()
+	}
+
+	return base.MetadataCipher
+}
+
 // deriveContentKey is exposing helper method to derive content key with project internals.
 //
 // NB: this is used with linkname in private/multipart.

--- a/upload.go
+++ b/upload.go
@@ -15,7 +15,7 @@ import (
 	"github.com/zeebo/errs"
 
 	"storj.io/common/leak"
-	"storj.io/common/pb"
+	"storj.io/common/usermeta"
 	"storj.io/eventkit"
 	"storj.io/uplink/private/eestream/scheduler"
 	"storj.io/uplink/private/metaclient"
@@ -131,9 +131,7 @@ func (project *Project) uploadObjectWithRetention(ctx context.Context, bucket, k
 type dynamicMetadata struct{ *metaclient.Object }
 
 func (dyn dynamicMetadata) Metadata() ([]byte, error) {
-	return pb.Marshal(&pb.SerializableMeta{
-		UserDefined: CustomMetadata(dyn.Object.Metadata).Clone(),
-	})
+	return usermeta.Marshal(dyn.Object.Metadata)
 }
 
 type streamUpload interface {


### PR DESCRIPTION
This PR introduces the `clear_metadata` field in [this common PR](https://github.com/storj/common/pull/16) into uplink library.

Known issues:
- Needs further changes in `UpdateObjectMetadataRequest`, and possibly other structures
- Needs unit test coverage
